### PR TITLE
Respect workerPath config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## A module for recording/exporting the output of Web Audio API nodes
 
-##Installation
+## Installation
 
 Install with npm, consume with [browserify](https://github.com/substack/node-browserify).
 

--- a/recorder.js
+++ b/recorder.js
@@ -7,7 +7,7 @@ var Recorder = function(source, cfg){
   this.node = (this.context.createScriptProcessor ||
                this.context.createJavaScriptNode).call(this.context,
                                                        bufferLen, 2, 2);
-  var worker = new Worker(WORKER_PATH);
+  var worker = new Worker(config.workerPath || WORKER_PATH);
   worker.onmessage = function(e){
     var blob = e.data;
     currCallback(blob);


### PR DESCRIPTION
Despite what it says on the docs, the worker path config is completely ignored in favour of a hardcoded value. This fixes it.